### PR TITLE
feat: omit __init__.py by adding it to .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = 
+    */__init__.py


### PR DESCRIPTION
# Description

__init__.py was part of the unit test coverage report. This pollutes the report.

## Issues

## Checklist

- [ ] Documented
- [x] Tested
